### PR TITLE
Enable `history-substring-search` as a default module

### DIFF
--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -38,6 +38,7 @@ zstyle ':prezto:load' pmodule \
   'spectrum' \
   'utility' \
   'completion' \
+  'history-substring-search' \
   'prompt'
 
 #


### PR DESCRIPTION
Resolves #1868

Please be sure to check out our [contributing guidelines](https://github.com/sorin-ionescu/prezto/blob/master/CONTRIBUTING.md)
before submitting your pull request.

Fixes #

## Proposed Changes

  -
  -
  -
